### PR TITLE
Show relative time ("N seconds/minutes ago (at HH:MM)") for recent clips

### DIFF
--- a/clipse_gui/utils.py
+++ b/clipse_gui/utils.py
@@ -25,6 +25,17 @@ def format_date(date_str):
         yesterday = today - timedelta(days=1)
         dt_date = dt.date()  # Compare dates only
 
+        delta_seconds = (now - dt).total_seconds()
+        if 0 <= delta_seconds < 3600:
+            clock = dt.strftime("%H:%M")
+            if delta_seconds < 5:
+                return f"just now (at {clock})"
+            if delta_seconds < 60:
+                return f"{int(delta_seconds)} seconds ago (at {clock})"
+            minutes = int(delta_seconds // 60)
+            unit = "minute" if minutes == 1 else "minutes"
+            return f"{minutes} {unit} ago (at {clock})"
+
         if dt_date == today:
             return f"Today at {dt.strftime('%H:%M')}"
         elif dt_date == yesterday:


### PR DESCRIPTION
## Summary

Adds a relative-time label to the list row timestamp for clips recorded within the last hour. Older items are unchanged.

- `just now (at HH:MM)` for < 5s
- `N seconds ago (at HH:MM)` for < 60s
- `N minutes ago (at HH:MM)` for < 1h
- everything older keeps the existing `Today at HH:MM` / `Yesterday at ...` / date formats

The change is contained to `clipse_gui/utils.py::format_date`. Implemented by checking `(now - dt).total_seconds()` against `3600` before falling through to the existing date logic, so behavior for non-recent items is byte-identical.

## Notes

- The label is computed once when the row is built (same as before), so it does not tick live while the window stays open. Happy to add a periodic refresh if you'd prefer.
- One-hour cutoff is hard-coded as `< 3600`; can be moved to a config value if useful.

## Test plan

- [x] Manually verified with synthetic timestamps at 3s, 25s, 70s, 15min, 59min50s, 2h, and 2d.
- [x] Restarted local clipse-gui and confirmed labels render correctly in the GUI.